### PR TITLE
Update CMakeLists.txt to be compatible with fuerte

### DIFF
--- a/cob_image_flip/CMakeLists.txt
+++ b/cob_image_flip/CMakeLists.txt
@@ -38,6 +38,7 @@ rosbuild_add_library(kinect_image_flip_nodelet ros/src/kinect_image_flip_nodelet
                                                ros/src/kinect_image_flip.cpp)
 rosbuild_add_executable(kinect_image_flip ros/src/kinect_image_flip_main.cpp
                                           ros/src/kinect_image_flip.cpp)
+rosbuild_link_boost(kinect_image_flip signals)
 
 rosbuild_add_compile_flags(kinect_image_flip_nodelet -D__LINUX__)
 rosbuild_add_compile_flags(kinect_image_flip -D__LINUX__)


### PR DESCRIPTION
This is required to compile under fuerte; should not break under electric.
