### PR TITLE
update to use non deprecated pluginlib macro

### DIFF
--- a/cob_cam3d_throttle/src/cam3d_throttle.cpp
+++ b/cob_cam3d_throttle/src/cam3d_throttle.cpp
@@ -170,6 +170,6 @@ private:
 };
 
 
-PLUGINLIB_DECLARE_CLASS(cob_cam3d_throttle, Cam3DThrottle, cob_cam3d_throttle::Cam3DThrottle, nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(cob_cam3d_throttle::Cam3DThrottle, nodelet::Nodelet);
 }
 

--- a/cob_image_flip/ros/src/image_flip_nodelet.cpp
+++ b/cob_image_flip/ros/src/image_flip_nodelet.cpp
@@ -61,4 +61,4 @@ public:
 }
 
 // watch the capitalization carefully
-PLUGINLIB_DECLARE_CLASS(cob_image_flip, ImageFlipNodelet, cob_image_flip::ImageFlipNodelet, nodelet::Nodelet)
+PLUGINLIB_EXPORT_CLASS(cob_image_flip::ImageFlipNodelet, nodelet::Nodelet)


### PR DESCRIPTION
This macro, deprecated for now 8 years, will be removed in the next ROS release (ROS Melodic)