### PR TITLE
removed unused Boost signals dependency

### DIFF
--- a/cob_image_flip/CMakeLists.txt
+++ b/cob_image_flip/CMakeLists.txt
@@ -29,7 +29,7 @@ find_package(catkin REQUIRED COMPONENTS
 	${catkin_BUILD_PACKAGES}
 )
 
-find_package(Boost REQUIRED COMPONENTS signals)
+find_package(Boost REQUIRED COMPONENTS)
 find_package(OpenCV REQUIRED)
 #find_package(PCL REQUIRED)
 


### PR DESCRIPTION
same as https://github.com/ipa320/cob_driver/pull/406